### PR TITLE
Improvements after Ben review

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ ecephys_processing_module.add(binned_aligned_spikes)
 ### Parameters and data structure
 The structure of the bins are characterized with the following parameters:
  
-* `milliseconds_from_event_to_first_bin`: The time in milliseconds from the event to the first bin. A negative value indicates that the first bin is before the event whereas a positive value indicates that the first bin is after the event. 
+* `milliseconds_from_event_to_first_bin`: The time in milliseconds from the event to the beginning of the first bin. A negative value indicates that the first bin is before the event whereas a positive value indicates that the first bin is after the event. 
 * `bin_width_in_milliseconds`: The width of each bin in milliseconds.
 
 
@@ -78,7 +78,7 @@ Note that in the diagram above, the `milliseconds_from_event_to_first_bin` is ne
 
 
 
-The `data` argument passed to the `BinnedAlignedSpikes` stores counts across all the event timestamps for each of the units. The data is a 3D array where the first dimension indexes the units, the second dimension indexes the event timestamps, and the third dimension indexes the bins where the counts are stored. The shape of the data is  `(number_of_units`, `number_of_event_repetitions`, `number_of_bins`). 
+The `data` argument passed to the `BinnedAlignedSpikes` stores counts across all the event timestamps for each of the units. The data is a 3D array where the first dimension indexes the units, the second dimension indexes the event timestamps, and the third dimension indexes the bins where the counts are stored. The shape of the data is  `(number_of_units`, `number_of_events`, `number_of_bins`). 
 
 
 The `event_timestamps` is used to store the timestamps of the events and should have the same length as the second dimension of `data`.

--- a/spec/ndx-binned-spikes.extensions.yaml
+++ b/spec/ndx-binned-spikes.extensions.yaml
@@ -5,15 +5,23 @@ groups:
   doc: A data interface for binned spike data aligned to an event (e.g. a stimuli
     or the beginning of a trial).
   attributes:
+  - name: name
+    dtype: text
+    value: BinnedAlignedSpikes
+    doc: The name of this container
+  - name: description
+    dtype: text
+    value: Spikes data binned and aligned to event timestamps.
+    doc: A description of what the data represents
   - name: bin_width_in_milliseconds
     dtype: float64
     doc: The length in milliseconds of the bins
   - name: milliseconds_from_event_to_first_bin
     dtype: float64
     default_value: 0.0
-    doc: The time in milliseconds from the event (e.g. a stimuli or the beginning
-      of a trial),to the first bin. Note that this is a negative number if the first
-      bin is before the event.
+    doc: The time in milliseconds from the event to the beginning of the first bin.
+      A negative value indicatesthat the first bin is before the event whereas a positive
+      value indicates that the first bin is after the event.
     required: false
   - name: units
     dtype:
@@ -26,17 +34,19 @@ groups:
     dtype: numeric
     dims:
     - - num_units
-      - number_of_event_repetitions
+      - number_of_events
       - number_of_bins
     shape:
     - - null
       - null
       - null
-    doc: TODO
+    doc: The binned data. It should be an array whose first dimension is the number
+      of units, the second dimension is the number of events, and the third dimension
+      is the number of bins.
   - name: event_timestamps
     dtype: float64
     dims:
-    - number_of_event_repetitions
+    - number_of_events
     shape:
     - null
-    doc: The timestamps at which the event occurred.
+    doc: The timestamps at which the events occurred.

--- a/src/pynwb/ndx_binned_spikes/testing/mock.py
+++ b/src/pynwb/ndx_binned_spikes/testing/mock.py
@@ -6,7 +6,7 @@ import numpy as np
 
 def mock_BinnedAlignedSpikes(
     number_of_units: int = 2,
-    number_of_event_repetitions: int = 4,
+    number_of_events: int = 4,
     number_of_bins: int = 3,
     bin_width_in_milliseconds: float = 20.0,
     milliseconds_from_event_to_first_bin: float = 1.0,
@@ -21,7 +21,7 @@ def mock_BinnedAlignedSpikes(
     ----------
     number_of_units : int, optional
         The number of different units (channels, neurons, etc.) to simulate.
-    number_of_event_repetitions : int, optional
+    number_of_events : int, optional
         The number of times an event is repeated.
     number_of_bins : int, optional
         The number of bins.
@@ -33,9 +33,9 @@ def mock_BinnedAlignedSpikes(
         Seed for the random number generator to ensure reproducibility.
     event_timestamps : np.ndarray, optional
         An array of timestamps for each event. If not provided, it will be automatically generated.
-        It should have size `number_of_event_repetitions`.
+        It should have size `number_of_events`.
     data : np.ndarray, optional
-        A 3D array of shape (number_of_units, number_of_event_repetitions, number_of_bins) representing
+        A 3D array of shape (number_of_units, number_of_events, number_of_bins) representing
         the binned spike data. If provided, it overrides the generation of mock data based on other parameters.
         Its shape should match the expected number of units, event repetitions, and bins.
 
@@ -62,21 +62,21 @@ def mock_BinnedAlignedSpikes(
     """
 
     if data is not None:
-        number_of_units, number_of_event_repetitions, number_of_bins = data.shape
+        number_of_units, number_of_events, number_of_bins = data.shape
     else:
         rng = np.random.default_rng(seed=seed)
-        data = rng.integers(low=0, high=100, size=(number_of_units, number_of_event_repetitions, number_of_bins))
+        data = rng.integers(low=0, high=100, size=(number_of_units, number_of_events, number_of_bins))
 
     if event_timestamps is None:
-        event_timestamps = np.arange(number_of_event_repetitions, dtype="float64")
+        event_timestamps = np.arange(number_of_events, dtype="float64")
     else:
         assert (
-            event_timestamps.shape[0] == number_of_event_repetitions
-        ), "The shape of `event_timestamps` does not match `number_of_event_repetitions`."
+            event_timestamps.shape[0] == number_of_events
+        ), "The shape of `event_timestamps` does not match `number_of_events`."
         event_timestamps = np.array(event_timestamps, dtype="float64")
 
     if event_timestamps.shape[0] != data.shape[1]:
-        raise ValueError("The shape of `event_timestamps` does not match `number_of_event_repetitions`.")
+        raise ValueError("The shape of `event_timestamps` does not match `number_of_events`.")
 
     binned_aligned_spikes = BinnedAlignedSpikes(
         bin_width_in_milliseconds=bin_width_in_milliseconds,

--- a/src/pynwb/tests/test_binned_aligned_spikes.py
+++ b/src/pynwb/tests/test_binned_aligned_spikes.py
@@ -21,7 +21,7 @@ class TestBinnedAlignedSpikesConstructor(TestCase):
 
         self.number_of_units = 2
         self.number_of_bins = 3
-        self.number_of_event_repetitions = 4
+        self.number_of_events = 4
         self.bin_width_in_milliseconds = 20.0
         self.milliseconds_from_event_to_first_bin = -100.0
         self.rng = np.random.default_rng(seed=0)
@@ -31,12 +31,12 @@ class TestBinnedAlignedSpikesConstructor(TestCase):
             high=100,
             size=(
                 self.number_of_units,
-                self.number_of_event_repetitions,
+                self.number_of_events,
                 self.number_of_bins,
             ),
         )
 
-        self.event_timestamps = np.arange(self.number_of_event_repetitions, dtype="float64")
+        self.event_timestamps = np.arange(self.number_of_events, dtype="float64")
 
         self.nwbfile = mock_NWBFile()
 
@@ -58,7 +58,7 @@ class TestBinnedAlignedSpikesConstructor(TestCase):
         )
 
         self.assertEqual(binned_aligned_spikes.data.shape[0], self.number_of_units)
-        self.assertEqual(binned_aligned_spikes.data.shape[1], self.number_of_event_repetitions)
+        self.assertEqual(binned_aligned_spikes.data.shape[1], self.number_of_events)
         self.assertEqual(binned_aligned_spikes.data.shape[2], self.number_of_bins)
 
     def test_constructor_units_region(self):

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -27,18 +27,21 @@ def main():
 
     binned_aligned_spikes_data = NWBDatasetSpec(
         name="data",
-        doc="TODO",
+        doc=(
+            "The binned data. It should be an array whose first dimension is the number of units, the second dimension "
+            "is the number of events, and the third dimension is the number of bins."
+            ),
         dtype="numeric",  # TODO should this be a uint64?
         shape=[(None, None, None)],
-        dims=[("num_units", "number_of_event_repetitions", "number_of_bins")],
+        dims=[("num_units", "number_of_events", "number_of_bins")],
     )
 
     event_timestamps = NWBDatasetSpec(
         name="event_timestamps",
-        doc="The timestamps at which the event occurred.",
+        doc="The timestamps at which the events occurred.",
         dtype="float64",
         shape=(None,),
-        dims=("number_of_event_repetitions",),
+        dims=("number_of_events",),
     )
 
     binned_aligned_spikes = NWBGroupSpec(
@@ -49,6 +52,18 @@ def main():
         datasets=[binned_aligned_spikes_data, event_timestamps],
         attributes=[
             NWBAttributeSpec(
+                name="name",
+                doc="The name of this container",
+                dtype="text",
+                value="BinnedAlignedSpikes",
+            ),
+            NWBAttributeSpec(
+                name="description",
+                doc="A description of what the data represents",
+                dtype="text",
+                value="Spikes data binned and aligned to event timestamps.",
+            ),
+            NWBAttributeSpec(
                 name="bin_width_in_milliseconds",
                 doc="The length in milliseconds of the bins",
                 dtype="float64",
@@ -56,9 +71,10 @@ def main():
             NWBAttributeSpec(
                 name="milliseconds_from_event_to_first_bin",
                 doc=(
-                    "The time in milliseconds from the event (e.g. a stimuli or the beginning of a trial),"
-                    "to the first bin. Note that this is a negative number if the first bin is before the event."
-                ),
+                "The time in milliseconds from the event to the beginning of the first bin. A negative value indicates"
+                "that the first bin is before the event whereas a positive value indicates that the first bin is "
+                "after the event." 
+            ),
                 dtype="float64",
                 default_value=0.0,
             ),


### PR DESCRIPTION
Some improvements after discussing with @bendichter this morning.
- Simpify the `__init__` of the class.
- Specificy that the "milliseconds_from_event_to_first_bin` is to the beginning of the first bin on the documentation.
- Remove non useful parenthesis on the docval for the unit table region.
- `number_of_event_repetitions` to `number_of_events`.
- Add description as an attribute.