### PR TITLE
Add structure for aggregated data `AggregatedBinnedAlignedSpikes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,10 @@ binned_aligned_spikes = BinnedAlignedSpikes(
 As with the previous example this can be then added to a processing module in an NWB file and written to disk using exactly the same code as before.
 
 ### Storing data from multiple events together
-In some cases, it is useful to store the data from multiple events together. For example, there are experiments where many stimuli are presented to the subject in a single session, and it might be desirable to store all the aggregated counts in a single object. For those cases, the `AggregatedBinnedAlignedSpikes` object can be used. This object is similar to the `BinnedAlignedSpikes` object but stores the data from all the events (in this case stimuli) together. Because not all events appear the same number of times, the `AggregatedBinnedAlignedSpikes` object stores a third variable, `event_indices`, that indicates which event each of the counts corresponds to. The object is created in the following way:
+In experiments where multiple stimuli are presented to a subject within a single session, it is often useful to store the aggregated spike counts from all events in a single object. For such cases, the `AggregatedBinnedAlignedSpikes` object is ideal. This object functions similarly to the `BinnedAlignedSpikes` object but is designed to store data from multiple events (e.g., different stimuli) together.
+
+Since events may not occur the same number of times, an homogeneous data structure is not possible. Therefore the `AggregatedBinnedAlignedSpikes` object includes an additional variable, event_indices, to indicate which event each set of counts corresponds to. You can create this object as follows:
+
 
 ```python
 from ndx_binned_spikes import AggregatedBinnedAlignedSpikes
@@ -194,14 +197,15 @@ aggregated_binned_aligned_spikes = AggregatedBinnedAlignedSpikes(
 )
 ```
 
-Where `aggregated_events_counts` is the number of repetitions of all the events for which we are aggregating data. For example, if we are aggregating data from two stimuli and the first stimulus appeared twice and the second stimulus appeared three times, then `aggregated_events_counts` would be 5.
+The `aggregated_events_counts` represents the total number of repetitions for all the events being aggregated. For example, if data is being aggregated from two stimuli where the first stimulus appeared twice and the second appeared three times, the aggregated_events_counts would be 5.
 
-The `event_indices` is an indicator vector which should be constructed such that `data[:, event_indices==event_index, :]` would correspond to the binned spike counts around the event with index `event_index`. The same data can be returned by calling the convenience method `aggregated_binned_aligned_spikes.get_data_for_event(event_index)`.
+The `event_indices` is an indicator vector that should be constructed so that `data[:, event_indices == event_index, :]` corresponds to the binned spike counts around the event with the specified event_index. You can retrieve the same data using the convenience method `aggregated_binned_aligned_spikes.get_data_for_event(event_index)`.
 
-Note as well that the timestamps need to be in ascending order and that they would map positionally to the event indices and the second dimension of the data. If they do not, then a `ValueError` will be raised. A convenience method `AggregatedBinnedAlignedSpikes.sort_data_by_timestamps(data=data, timestamps=timestamps, event_indices=event_indices)` is provided that returns the data organized as expected. It can be used like this:
+It's important to note that the timestamps must be in ascending order and must correspond positionally to the event indices and the second dimension of the data. If they are not, a ValueError will be raised. To help organize the data correctly, you can use the convenience method `AggregatedBinnedAlignedSpikes.sort_data_by_timestamps(data=data, timestamps=timestamps, event_indices=event_indices)`, which ensures the data is properly sorted. Here’s how it can be used:
 
 ```python
 sorted_data, sorted_timestamps, sorted_event_indices = AggregatedBinnedAlignedSpikes.sort_data_by_timestamps(data=data, timestamps=timestamps, event_indices=event_indices)
+
 aggregated_binned_aligned_spikes = AggregatedBinnedAlignedSpikes(
     bin_width_in_milliseconds=bin_width_in_milliseconds,
     milliseconds_from_event_to_first_bin=milliseconds_from_event_to_first_bin,
@@ -230,7 +234,7 @@ aggregated_binned_aligned_spikes = AggregatedBinnedAlignedSpikes(
 
 #### Example of building an `AggregatedBinnedAlignedSpikes` object from scratch
 
-To make the example more concrete and further the understanding of how this object works, let's work through the following example. Suppose that we have data for two distinct events (say two different stimuli) as we would have for the `BinnedAlignedSpikes` examples above and their timestamps:
+To better understand how this object works, let's consider a specific example. Suppose we have data for two distinct events (such as two different stimuli) and their associated timestamps, similar to the `BinnedAlignedSpikes` examples mentioned earlier:
 
 ```python
 import numpy as np

--- a/spec/ndx-binned-spikes.extensions.yaml
+++ b/spec/ndx-binned-spikes.extensions.yaml
@@ -62,7 +62,7 @@ groups:
     doc: The name of this container
   - name: description
     dtype: text
-    value: Spikes data binned and aligned to event timestamps.
+    value: Spikes data binned and aligned to the timestamps of multiple events.
     doc: A description of what the data represents
   - name: bin_width_in_milliseconds
     dtype: float64

--- a/spec/ndx-binned-spikes.extensions.yaml
+++ b/spec/ndx-binned-spikes.extensions.yaml
@@ -48,3 +48,52 @@ groups:
     neurodata_type_inc: DynamicTableRegion
     doc: A reference to the Units table region that contains the units of the data.
     quantity: '?'
+- neurodata_type_def: AggregatedBinnedAlignedSpikes
+  neurodata_type_inc: NWBDataInterface
+  default_name: AggregatedBinnedAlignedSpikes
+  doc: A data interface for aggregated binned spike data aligned to an multiple events
+    (e.g. a stimuli or the beginning of a trial).
+  attributes:
+  - name: name
+    dtype: text
+    value: BinnedAlignedSpikes
+    doc: The name of this container
+  - name: description
+    dtype: text
+    value: Spikes data binned and aligned to event timestamps.
+    doc: A description of what the data represents
+  - name: bin_width_in_milliseconds
+    dtype: float64
+    doc: The length in milliseconds of the bins
+  - name: milliseconds_from_event_to_first_bin
+    dtype: float64
+    default_value: 0.0
+    doc: The time in milliseconds from the event to the beginning of the first bin.
+      A negative value indicatesthat the first bin is before the event whereas a positive
+      value indicates that the first bin is after the event.
+    required: false
+  datasets:
+  - name: data
+    dtype: numeric
+    dims:
+    - num_units
+    - number_of_events
+    - number_of_bins
+    shape:
+    - null
+    - null
+    - null
+    doc: The binned data. It should be an array whose first dimension is the number
+      of units, the second dimension is the total number of events of all stimuli,
+      and the third dimension is the number of bins.
+  - name: event_index
+    dtype: int64
+    dims:
+    - number_of_events
+    shape:
+    - null
+    doc: The index of the event that each row of the data corresponds to.
+  - name: units_region
+    neurodata_type_inc: DynamicTableRegion
+    doc: A reference to the Units table region that contains the units of the data.
+    quantity: '?'

--- a/spec/ndx-binned-spikes.extensions.yaml
+++ b/spec/ndx-binned-spikes.extensions.yaml
@@ -51,7 +51,7 @@ groups:
 - neurodata_type_def: AggregatedBinnedAlignedSpikes
   neurodata_type_inc: NWBDataInterface
   default_name: AggregatedBinnedAlignedSpikes
-  doc: A data interface for aggregated binned spike data aligned to an multiple events
+  doc: A data interface for aggregated binned spike data aligned to multiple events
     (e.g. a stimuli or the beginning of a trial).
   attributes:
   - name: name
@@ -93,6 +93,13 @@ groups:
     shape:
     - null
     doc: The index of the event that each row of the data corresponds to.
+  - name: event_timestamps
+    dtype: float64
+    dims:
+    - number_of_events
+    shape:
+    - null
+    doc: The timestamps at which the events occurred.
   - name: units_region
     neurodata_type_inc: DynamicTableRegion
     doc: A reference to the Units table region that contains the units of the data.

--- a/spec/ndx-binned-spikes.extensions.yaml
+++ b/spec/ndx-binned-spikes.extensions.yaml
@@ -51,8 +51,10 @@ groups:
 - neurodata_type_def: AggregatedBinnedAlignedSpikes
   neurodata_type_inc: NWBDataInterface
   default_name: AggregatedBinnedAlignedSpikes
-  doc: A data interface for aggregated binned spike data aligned to multiple events
-    (e.g. a stimuli or the beginning of a trial).
+  doc: A data interface for aggregated binned spike data aligned to multiple events.
+    The data for all the events is concatenated along the second dimension and a second
+    array, event_indices, is used to keep track of which event each row of the data
+    corresponds to.
   attributes:
   - name: name
     dtype: text
@@ -93,7 +95,7 @@ groups:
     shape:
     - null
     doc: The index of the event that each row of the data corresponds to.
-  - name: event_timestamps
+  - name: timestamps
     dtype: float64
     dims:
     - number_of_events

--- a/spec/ndx-binned-spikes.extensions.yaml
+++ b/spec/ndx-binned-spikes.extensions.yaml
@@ -86,7 +86,7 @@ groups:
     doc: The binned data. It should be an array whose first dimension is the number
       of units, the second dimension is the total number of events of all stimuli,
       and the third dimension is the number of bins.
-  - name: event_index
+  - name: event_indices
     dtype: int64
     dims:
     - number_of_events

--- a/src/pynwb/ndx_binned_spikes/__init__.py
+++ b/src/pynwb/ndx_binned_spikes/__init__.py
@@ -160,7 +160,7 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
             ),
         },
         {
-            "name": "event_index",
+            "name": "event_indices",
             "type": "array_data",
             "doc": "The timestamps at which the events occurred.",
             "shape": (None,),
@@ -181,7 +181,14 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
         for key in kwargs:
             setattr(self, key, kwargs[key])
         
-
+    # Should this return an instance of BinnedAlignedSpikes or just the data as it is?
+    # Going with the simple one for the moment
+    def get_data_for_stimuli(self, event_index):
+        
+        mask = self.event_indices == event_index
+        binned_spikes_for_unit = self.data[:, mask, :]
+        
+        return binned_spikes_for_unit
 
 
 # Remove these functions from the package

--- a/src/pynwb/ndx_binned_spikes/__init__.py
+++ b/src/pynwb/ndx_binned_spikes/__init__.py
@@ -1,5 +1,5 @@
 import os
-import numpy as np 
+import numpy as np
 from pynwb import load_namespaces, get_class
 from pynwb import register_class
 from pynwb.core import NWBDataInterface
@@ -32,7 +32,7 @@ class BinnedAlignedSpikes(NWBDataInterface):
         "milliseconds_from_event_to_first_bin",
         "data",
         "event_timestamps",
-        {"name":"units_region", "child":True},
+        {"name": "units_region", "child": True},
     )
 
     DEFAULT_NAME = "BinnedAlignedSpikes"
@@ -62,7 +62,7 @@ class BinnedAlignedSpikes(NWBDataInterface):
             "doc": (
                 "The time in milliseconds from the event to the beginning of the first bin. A negative value indicates"
                 "that the first bin is before the event whereas a positive value indicates that the first bin is "
-                "after the event." 
+                "after the event."
             ),
             "default": 0.0,
         },
@@ -97,12 +97,13 @@ class BinnedAlignedSpikes(NWBDataInterface):
             raise ValueError("The number of event timestamps must match the number of event repetitions in the data.")
 
         super().__init__(name=kwargs["name"])
-        
+
         name = kwargs.pop("name")
         super().__init__(name=name)
 
         for key in kwargs:
             setattr(self, key, kwargs[key])
+
 
 @register_class(neurodata_type="AggregatedBinnedAlignedSpikes", namespace="ndx-binned-spikes")  # noqa
 class AggregatedBinnedAlignedSpikes(NWBDataInterface):
@@ -112,13 +113,13 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
         "bin_width_in_milliseconds",
         "milliseconds_from_event_to_first_bin",
         "data",
-        "event_timestamps",
+        "timestamps",
         "event_indices",
-        {"name":"units_region", "child":True},  #TODO, I forgot why this is included
+        {"name": "units_region", "child": True},  # TODO, I forgot why this is included
     )
 
     DEFAULT_NAME = "AggregatedBinnedAlignedSpikes"
-    DEFAULT_DESCRIPTION = "Spikes data binned and aligned from multiple events."
+    DEFAULT_DESCRIPTION = "Spikes data binned and aligned to the timestamps of multiple events."
 
     @docval(
         {
@@ -144,7 +145,7 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
             "doc": (
                 "The time in milliseconds from the event to the beginning of the first bin. A negative value indicates"
                 "that the first bin is before the event whereas a positive value indicates that the first bin is "
-                "after the event." 
+                "after the event."
             ),
             "default": 0.0,
         },
@@ -181,7 +182,6 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
     )
     def __init__(self, **kwargs):
 
-        
         name = kwargs.pop("name")
         super().__init__(name=name)
 
@@ -189,34 +189,33 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
         timestamps = kwargs["timestamps"]
         event_indices = kwargs["event_indices"]
         data = kwargs["data"]
-        
+
         sorted_indices = np.argsort(timestamps)
         data = data[:, sorted_indices, :]
         timestamps = timestamps[sorted_indices]
         event_indices = event_indices[sorted_indices]
-        
+
         kwargs["data"] = data
         kwargs["timestamps"] = timestamps
         kwargs["event_indices"] = event_indices
-        
 
         for key in kwargs:
             setattr(self, key, kwargs[key])
-        
+
     # Should this return an instance of BinnedAlignedSpikes or just the data as it is?
     # Going with the simple one for the moment
     def get_data_for_stimuli(self, event_index):
-        
+
         mask = self.event_indices == event_index
         binned_spikes_for_unit = self.data[:, mask, :]
-        
+
         return binned_spikes_for_unit
-    
+
     def get_timestamps_for_stimuli(self, event_index):
-        
+
         mask = self.event_indices == event_index
         timestamps = self.timestamps[mask]
-        
+
         return timestamps
 
 

--- a/src/pynwb/ndx_binned_spikes/__init__.py
+++ b/src/pynwb/ndx_binned_spikes/__init__.py
@@ -106,6 +106,80 @@ class BinnedAlignedSpikes(NWBDataInterface):
 
         for key in kwargs:
             setattr(self, key, kwargs[key])
+
+@register_class(neurodata_type="BinnedAlignedSpikes", namespace="ndx-binned-spikes")  # noqa
+class AggregatedBinnedAlignedSpikes(NWBDataInterface):
+    __nwbfields__ = (
+        "name",
+        "description",
+        "bin_width_in_milliseconds",
+        "milliseconds_from_event_to_first_bin",
+        "data",
+        "event_timestamps",
+        {"name":"units_region", "child":True},  #TODO, I forgot why this is included
+    )
+
+    DEFAULT_NAME = "AggregatedBinnedAlignedSpikes"
+    DEFAULT_DESCRIPTION = "Spikes data binned and aligned from multiple events."
+
+    @docval(
+        {
+            "name": "name",
+            "type": str,
+            "doc": "The name of this container",
+            "default": DEFAULT_NAME,
+        },
+        {
+            "name": "description",
+            "type": str,
+            "doc": "A description of what the data represents",
+            "default": DEFAULT_DESCRIPTION,
+        },
+        {
+            "name": "bin_width_in_milliseconds",
+            "type": float,
+            "doc": "The length in milliseconds of the bins",
+        },
+        {
+            "name": "milliseconds_from_event_to_first_bin",
+            "type": float,
+            "doc": (
+                "The time in milliseconds from the event to the beginning of the first bin. A negative value indicates"
+                "that the first bin is before the event whereas a positive value indicates that the first bin is "
+                "after the event." 
+            ),
+            "default": 0.0,
+        },
+        {
+            "name": "data",
+            "type": "array_data",
+            "shape": [(None, None, None)],
+            "doc": (
+                "The binned data. It should be an array whose first dimension is the number of units, "
+                "the second dimension is the number of events, and the third dimension is the number of bins."
+            ),
+        },
+        {
+            "name": "event_index",
+            "type": "array_data",
+            "doc": "The timestamps at which the events occurred.",
+            "shape": (None,),
+        },
+        {
+            "name": "units_region",
+            "type": DynamicTableRegion,
+            "doc": "A reference to the Units table region that contains the units of the data.",
+            "default": None,
+        },
+    )
+    def __init__(self, **kwargs):
+
+
+        name = kwargs.pop("name")
+        super().__init__(name=name)
+
+        for key in kwargs:
+            setattr(self, key, kwargs[key])
         
 
 

--- a/src/pynwb/ndx_binned_spikes/__init__.py
+++ b/src/pynwb/ndx_binned_spikes/__init__.py
@@ -107,7 +107,7 @@ class BinnedAlignedSpikes(NWBDataInterface):
         for key in kwargs:
             setattr(self, key, kwargs[key])
 
-@register_class(neurodata_type="BinnedAlignedSpikes", namespace="ndx-binned-spikes")  # noqa
+@register_class(neurodata_type="AggregatedBinnedAlignedSpikes", namespace="ndx-binned-spikes")  # noqa
 class AggregatedBinnedAlignedSpikes(NWBDataInterface):
     __nwbfields__ = (
         "name",

--- a/src/pynwb/ndx_binned_spikes/__init__.py
+++ b/src/pynwb/ndx_binned_spikes/__init__.py
@@ -158,9 +158,12 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
             ),
         },
         {
-            "name": "event_timestamps",
+            "name": "timestamps",
             "type": "array_data",
-            "doc": "The timestamps at which the events occurred. It is assume that they map positionally to the second index of the data.",
+            "doc": (
+                "The timestamps at which the events occurred. It is assumed that they map positionally to "
+                "the second index of the data.",
+            ),
             "shape": (None,),
         },
         {
@@ -183,7 +186,7 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
         super().__init__(name=name)
 
         # Sort the data by the timestamps
-        timestamps = kwargs["event_timestamps"]
+        timestamps = kwargs["timestamps"]
         event_indices = kwargs["event_indices"]
         data = kwargs["data"]
         
@@ -193,7 +196,7 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
         event_indices = event_indices[sorted_indices]
         
         kwargs["data"] = data
-        kwargs["event_timestamps"] = timestamps
+        kwargs["timestamps"] = timestamps
         kwargs["event_indices"] = event_indices
         
 
@@ -212,7 +215,7 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
     def get_timestamps_for_stimuli(self, event_index):
         
         mask = self.event_indices == event_index
-        timestamps = self.event_timestamps[mask]
+        timestamps = self.timestamps[mask]
         
         return timestamps
 

--- a/src/pynwb/ndx_binned_spikes/__init__.py
+++ b/src/pynwb/ndx_binned_spikes/__init__.py
@@ -1,5 +1,6 @@
 import os
 import numpy as np
+from typing import Tuple
 from pynwb import load_namespaces, get_class
 from pynwb import register_class
 from pynwb.core import NWBDataInterface
@@ -185,19 +186,19 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
         name = kwargs.pop("name")
         super().__init__(name=name)
 
-        # Sort the data by the timestamps
-        timestamps = kwargs["timestamps"]
-        event_indices = kwargs["event_indices"]
-        data = kwargs["data"]
+        # # Sort the data by the timestamps
+        # timestamps = kwargs["timestamps"]
+        # event_indices = kwargs["event_indices"]
+        # data = kwargs["data"]
 
-        sorted_indices = np.argsort(timestamps)
-        data = data[:, sorted_indices, :]
-        timestamps = timestamps[sorted_indices]
-        event_indices = event_indices[sorted_indices]
+        # sorted_indices = np.argsort(timestamps)
+        # data = data[:, sorted_indices, :]
+        # timestamps = timestamps[sorted_indices]
+        # event_indices = event_indices[sorted_indices]
 
-        kwargs["data"] = data
-        kwargs["timestamps"] = timestamps
-        kwargs["event_indices"] = event_indices
+        # kwargs["data"] = data
+        # kwargs["timestamps"] = timestamps
+        # kwargs["event_indices"] = event_indices
 
         for key in kwargs:
             setattr(self, key, kwargs[key])
@@ -217,6 +218,20 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
         timestamps = self.timestamps[mask]
 
         return timestamps
+
+    @staticmethod
+    def sort_data_by_time(
+        data: np.ndarray,
+        timestamps: np.ndarray,
+        event_indices: np.ndarray,
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        
+        sorted_indices = np.argsort(timestamps)
+        data = data[:, sorted_indices, :]
+        timestamps = timestamps[sorted_indices]
+        event_indices = event_indices[sorted_indices]
+
+        return data, timestamps, event_indices
 
 
 # Remove these functions from the package

--- a/src/pynwb/ndx_binned_spikes/__init__.py
+++ b/src/pynwb/ndx_binned_spikes/__init__.py
@@ -186,19 +186,21 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
         name = kwargs.pop("name")
         super().__init__(name=name)
 
-        # # Sort the data by the timestamps
-        # timestamps = kwargs["timestamps"]
-        # event_indices = kwargs["event_indices"]
-        # data = kwargs["data"]
+        timestamps = kwargs["timestamps"]
+        event_indices = kwargs["event_indices"]
+        data = kwargs["data"]
 
-        # sorted_indices = np.argsort(timestamps)
-        # data = data[:, sorted_indices, :]
-        # timestamps = timestamps[sorted_indices]
-        # event_indices = event_indices[sorted_indices]
+        assert data.shape[1] == timestamps.shape[0], "The number of timestamps must match the second axis of data."
+        assert event_indices.shape[0] == timestamps.shape[0], "The number of timestamps must match the event_indices."
 
-        # kwargs["data"] = data
-        # kwargs["timestamps"] = timestamps
-        # kwargs["event_indices"] = event_indices
+        # Assert timestamps are monotonically increasing
+        if not np.all(np.diff(kwargs["timestamps"]) >= 0):
+            error_msg = (
+                "The timestamps must be monotonically increasing and the data and event_indices "
+                "must be sorted by timestamps. Use the `sort_data_by_timestamps` method to do this "
+                "automatically before passing the data to the constructor."
+            )
+            raise ValueError(error_msg)
 
         for key in kwargs:
             setattr(self, key, kwargs[key])
@@ -220,12 +222,12 @@ class AggregatedBinnedAlignedSpikes(NWBDataInterface):
         return timestamps
 
     @staticmethod
-    def sort_data_by_time(
+    def sort_data_by_timestamps(
         data: np.ndarray,
         timestamps: np.ndarray,
         event_indices: np.ndarray,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        
+
         sorted_indices = np.argsort(timestamps)
         data = data[:, sorted_indices, :]
         timestamps = timestamps[sorted_indices]

--- a/src/pynwb/ndx_binned_spikes/testing/mock.py
+++ b/src/pynwb/ndx_binned_spikes/testing/mock.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from ndx_binned_spikes import BinnedAlignedSpikes
+from ndx_binned_spikes import BinnedAlignedSpikes, AggregatedBinnedAlignedSpikes
 import numpy as np
 from pynwb import NWBFile
 from pynwb.misc import Units
@@ -89,12 +89,12 @@ def mock_BinnedAlignedSpikes(
         milliseconds_from_event_to_first_bin=milliseconds_from_event_to_first_bin,
         data=data,
         event_timestamps=event_timestamps,
-        units_region=units_region
+        units_region=units_region,
     )
     return binned_aligned_spikes
 
 
-#TODO: Remove once pynwb 2.7.0 is released and use the mock class there
+# TODO: Remove once pynwb 2.7.0 is released and use the mock class there
 def mock_Units(
     num_units: int = 10,
     max_spikes_per_unit: int = 10,
@@ -122,3 +122,119 @@ def mock_Units(
         nwbfile.units = units_table
 
     return units_table
+
+
+"""
+Ok, so for the first structure what we can align to:
+- A specific stimulus (the event here is every time the stimulus occurs)
+- A column of the trials table (e.g. ). The event here is every trial
+- A time column of any dynamic table.
+- Add event from ndx-events
+
+When do we need to aggregate?
+Stimulus, because not all stimulus happen the same number of times. 
+What else is inhomogeneous in this way? A column of the trials table
+"""
+
+
+def mock_AggregatedBinnedAlignedSpikes(
+    number_of_units: int = 2,
+    number_of_bins: int = 3,
+    aggregated_events_counts: int = 5,
+    number_of_events: int = 2,
+    bin_width_in_milliseconds: float = 20.0,
+    milliseconds_from_event_to_first_bin: float = 1.0,
+    seed: int = 0,
+    event_indices: Optional[np.ndarray] = None,
+    timestamps: Optional[np.ndarray] = None,
+    data: Optional[np.ndarray] = None,
+    units_region: Optional[DynamicTableRegion] = None,
+) -> "AggregatedBinnedAlignedSpikes":
+    """
+    Generate a mock AggregatedBinnedAlignedSpikes object with specified parameters or from given data.
+
+    Parameters
+    ----------
+    number_of_units : int, optional
+        The number of different units (channels, neurons, etc.) to simulate.
+    number_of_events : int, optional
+        The number of timestamps of the event that the data is aligned to.
+    number_of_bins : int, optional
+        The number of bins.
+    number_of_different_events : int, optional
+        The number of different events that the data is aligned to.
+    bin_width_in_milliseconds : float, optional
+        The width of each bin in milliseconds.
+    milliseconds_from_event_to_first_bin : float, optional
+        The time in milliseconds from the event start to the first bin.
+    seed : int, optional
+        Seed for the random number generator to ensure reproducibility.
+    data : np.ndarray, optional
+        A 3D array of shape (number_of_units, number_of_events, number_of_bins) representing
+        the binned spike data. If provided, it overrides the generation of mock data based on other parameters.
+        Its shape should match the expected number of units, event repetitions, and bins.
+    timestamps : np.ndarray, optional
+        An array of timestamps for each event. If not provided, it will be automatically generated.
+        It should have size `number_of_events`.
+    units_region: DynamicTableRegion, optional
+        A reference to the Units table region that contains the units of the data.
+    event_indices : np.ndarray, optional
+        An array of indices for each event. If not provided, it will be automatically generated.
+    Returns
+    -------
+    AggregatedBinnedAlignedSpikes
+        A mock AggregatedBinnedAlignedSpikes object populated with the provided or generated data and parameters.
+    """
+
+    if data is not None:
+        number_of_units, aggregated_events_counts, number_of_bins = data.shape
+    else:
+        rng = np.random.default_rng(seed=seed)
+        data = rng.integers(low=0, high=100, size=(number_of_units, aggregated_events_counts, number_of_bins))
+
+    if timestamps is None:
+        timestamps = np.arange(aggregated_events_counts, dtype="float64")
+
+    if event_indices is None:
+        event_indices = np.zeros(aggregated_events_counts, dtype=int)
+        all_indices = np.arange(number_of_events, dtype=int)
+
+        # Ensure all indices appear at least once
+        event_indices[:number_of_events] = rng.choice(all_indices, size=number_of_events, replace=False)
+        # Then fill the rest randomly
+        event_indices[number_of_events:] = rng.choice(
+            event_indices[:number_of_events],
+            size=aggregated_events_counts - number_of_events,
+            replace=True,
+        )
+
+    # Assert data shapes
+    assertion_msg = (
+        "The shape of `data` should be (number_of_units, aggregated_events_counts, number_of_bins), "
+        f"The actual shape is {data.shape} \n "
+        "but {number_of_bins=}, {aggregated_events_counts=}, {number_of_units=} was passed"
+    )
+    assert data.shape == (number_of_units, aggregated_events_counts, number_of_bins), assertion_msg
+
+    if timestamps.shape[0] != aggregated_events_counts:
+        raise ValueError("The shape of `timestamps` does not match `aggregated_events_counts`.")
+        
+    assert (
+        event_indices.shape[0] == aggregated_events_counts
+    ), "The shape of `event_indices` does not match `aggregated_events_counts`."
+    event_indices = np.array(event_indices, dtype=int)
+
+    # Sort the data by timestamps
+    sorted_indices = np.argsort(timestamps)
+    data = data[:, sorted_indices, :]
+    event_indices = event_indices[sorted_indices]
+
+    aggreegated_binned_aligned_spikes = AggregatedBinnedAlignedSpikes(
+        bin_width_in_milliseconds=bin_width_in_milliseconds,
+        milliseconds_from_event_to_first_bin=milliseconds_from_event_to_first_bin,
+        data=data,
+        timestamps=timestamps,
+        event_indices=event_indices,
+        units_region=units_region,
+    )
+    return aggreegated_binned_aligned_spikes

--- a/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
+++ b/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
@@ -20,7 +20,7 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         self.milliseconds_from_event_to_first_bin = -100.0        
 
         # Two units in total and 4 bins, and event with two timestamps
-        data_for_first_event_instance = np.array(
+        self.data_for_first_event_instance = np.array(
             [
                 # Unit 1 data
                 [
@@ -36,7 +36,7 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         )
 
         # Also two units and 4 bins but this event appeared three times
-        data_for_second_event_instance = np.array(
+        self.data_for_second_event_instance = np.array(
             [
                 # Unit 1 data
                 [
@@ -53,14 +53,14 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
             ]
         )
 
-        self.event_index = np.concatenate(
+        self.event_indices = np.concatenate(
             [
                 np.full(instance.shape[1], i)
-                for i, instance in enumerate([data_for_first_event_instance, data_for_second_event_instance])
+                for i, instance in enumerate([self.data_for_first_event_instance, self.data_for_second_event_instance])
             ]
         )
 
-        self.data = np.concatenate([data_for_first_event_instance, data_for_second_event_instance], axis=1)
+        self.data = np.concatenate([self.data_for_first_event_instance, self.data_for_second_event_instance], axis=1)
 
 
     def test_constructor(self):
@@ -70,11 +70,11 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
             bin_width_in_milliseconds=self.bin_width_in_milliseconds,
             milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
             data=self.data,
-            event_index=self.event_index,
+            event_indices=self.event_indices,
         )
 
         np.testing.assert_array_equal(aggregated_binnned_align_spikes.data, self.data)
-        np.testing.assert_array_equal(aggregated_binnned_align_spikes.event_index, self.event_index)
+        np.testing.assert_array_equal(aggregated_binnned_align_spikes.event_indices, self.event_indices)
         self.assertEqual(aggregated_binnned_align_spikes.bin_width_in_milliseconds, self.bin_width_in_milliseconds)
         self.assertEqual(
             aggregated_binnned_align_spikes.milliseconds_from_event_to_first_bin, self.milliseconds_from_event_to_first_bin
@@ -83,3 +83,18 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         self.assertEqual(aggregated_binnned_align_spikes.data.shape[0], self.number_of_units)
         self.assertEqual(aggregated_binnned_align_spikes.data.shape[1], self.number_of_events)
         self.assertEqual(aggregated_binnned_align_spikes.data.shape[2], self.number_of_bins)
+
+
+    def test_get_single_event_data_method(self):
+        
+        aggregated_binnned_align_spikes = AggregatedBinnedAlignedSpikes(
+            bin_width_in_milliseconds=self.bin_width_in_milliseconds,
+            milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
+            data=self.data,
+            event_indices=self.event_indices,
+        )
+        
+        
+        data_for_stimuli_1 = aggregated_binnned_align_spikes.get_data_for_stimuli(event_index=0)
+        
+        np.testing.assert_allclose(data_for_stimuli_1, self.data_for_first_event_instance)

--- a/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
+++ b/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
@@ -1,0 +1,85 @@
+import numpy as np
+
+from pynwb import NWBHDF5IO
+from pynwb.testing.mock.file import mock_NWBFile
+from pynwb.testing import TestCase, remove_test_file
+from ndx_binned_spikes import AggregatedBinnedAlignedSpikes
+
+
+class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
+    """Simple unit test for creating a AggregatedBinnedAlignedSpikes."""
+
+    def setUp(self):
+        """Set up an NWB file.."""
+
+        self.number_of_units = 2
+        self.number_of_bins = 4
+        self.number_of_events = 5
+
+        self.bin_width_in_milliseconds = 20.0
+        self.milliseconds_from_event_to_first_bin = -100.0        
+
+        # Two units in total and 4 bins, and event with two timestamps
+        data_for_first_event_instance = np.array(
+            [
+                # Unit 1 data
+                [
+                    [0, 1, 2, 3],  # Bin counts around the first timestamp
+                    [4, 5, 6, 7],  # Bin counts around the second timestamp
+                ],
+                # Unit 2 data
+                [
+                    [8, 9, 10, 11],  # Bin counts around the first timestamp
+                    [12, 13, 14, 15],  # Bin counts around the second timestamp
+                ],
+            ],
+        )
+
+        # Also two units and 4 bins but this event appeared three times
+        data_for_second_event_instance = np.array(
+            [
+                # Unit 1 data
+                [
+                    [0, 1, 2, 3],  # Bin counts around the first timestamp
+                    [4, 5, 6, 7],  # Bin counts around the second timestamp
+                    [8, 9, 10, 11],  # Bin counts around the third timestamp
+                ],
+                # Unit 2 data
+                [
+                    [12, 13, 14, 15],  # Bin counts around the first timestamp
+                    [16, 17, 18, 19],  # Bin counts around the second timestamp
+                    [20, 21, 22, 23],  # Bin counts around the third timestamp
+                ],
+            ]
+        )
+
+        self.event_index = np.concatenate(
+            [
+                np.full(instance.shape[1], i)
+                for i, instance in enumerate([data_for_first_event_instance, data_for_second_event_instance])
+            ]
+        )
+
+        self.data = np.concatenate([data_for_first_event_instance, data_for_second_event_instance], axis=1)
+
+
+    def test_constructor(self):
+        """Test that the constructor for BinnedAlignedSpikes sets values as expected."""
+
+        aggregated_binnned_align_spikes = AggregatedBinnedAlignedSpikes(
+            bin_width_in_milliseconds=self.bin_width_in_milliseconds,
+            milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
+            data=self.data,
+            event_index=self.event_index,
+        )
+
+        np.testing.assert_array_equal(aggregated_binnned_align_spikes.data, self.data)
+        np.testing.assert_array_equal(aggregated_binnned_align_spikes.event_index, self.event_index)
+        self.assertEqual(aggregated_binnned_align_spikes.bin_width_in_milliseconds, self.bin_width_in_milliseconds)
+        self.assertEqual(
+            aggregated_binnned_align_spikes.milliseconds_from_event_to_first_bin, self.milliseconds_from_event_to_first_bin
+        )
+
+        self.assertEqual(aggregated_binnned_align_spikes.data.shape[0], self.number_of_units)
+        self.assertEqual(aggregated_binnned_align_spikes.data.shape[1], self.number_of_events)
+        self.assertEqual(aggregated_binnned_align_spikes.data.shape[2], self.number_of_bins)

--- a/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
+++ b/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
@@ -72,14 +72,19 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         self.sorted_indices = np.argsort(self.timestamps)
 
     def test_constructor(self):
-        """Test that the constructor for BinnedAlignedSpikes sets values as expected."""
+        """Test that the constructor for AggregatedBinnedAlignedSpikes sets values as expected."""
 
+        data, timestamps, event_indices = AggregatedBinnedAlignedSpikes.sort_data_by_time(
+            self.data,
+            self.timestamps,
+            self.event_indices,
+        )
         aggregated_binnned_align_spikes = AggregatedBinnedAlignedSpikes(
             bin_width_in_milliseconds=self.bin_width_in_milliseconds,
             milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
-            data=self.data,
-            timestamps=self.timestamps,
-            event_indices=self.event_indices,
+            data=data,
+            timestamps=timestamps,
+            event_indices=event_indices,
         )
 
         np.testing.assert_array_equal(aggregated_binnned_align_spikes.data, self.data[:, self.sorted_indices, :])

--- a/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
+++ b/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
@@ -74,11 +74,22 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
     def test_constructor(self):
         """Test that the constructor for AggregatedBinnedAlignedSpikes sets values as expected."""
 
-        data, timestamps, event_indices = AggregatedBinnedAlignedSpikes.sort_data_by_time(
+        with self.assertRaises(ValueError):
+            AggregatedBinnedAlignedSpikes(
+                bin_width_in_milliseconds=self.bin_width_in_milliseconds,
+                milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
+                data=self.data,
+                timestamps=self.timestamps,
+                event_indices=self.event_indices,
+            )
+        
+        
+        data, timestamps, event_indices = AggregatedBinnedAlignedSpikes.sort_data_by_timestamps(
             self.data,
             self.timestamps,
             self.event_indices,
         )
+        
         aggregated_binnned_align_spikes = AggregatedBinnedAlignedSpikes(
             bin_width_in_milliseconds=self.bin_width_in_milliseconds,
             milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
@@ -104,12 +115,19 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
 
     def test_get_single_event_data_methods(self):
 
+        
+        data, timestamps, event_indices = AggregatedBinnedAlignedSpikes.sort_data_by_timestamps(
+            self.data,
+            self.timestamps,
+            self.event_indices,
+        )
+
         aggregated_binnned_align_spikes = AggregatedBinnedAlignedSpikes(
             bin_width_in_milliseconds=self.bin_width_in_milliseconds,
             milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
-            data=self.data,
-            timestamps=self.timestamps,
-            event_indices=self.event_indices,
+            data=data,
+            timestamps=timestamps,
+            event_indices=event_indices,
         )
 
         data_for_stimuli_1 = aggregated_binnned_align_spikes.get_data_for_stimuli(event_index=0)

--- a/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
+++ b/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
@@ -51,8 +51,8 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
             ]
         )
 
-        self.event_timestamps_first_event = [5.0, 15.0]
-        self.event_timestamps_second_event = [1.0, 10.0, 35.0]
+        self.timestamps_first_event = [5.0, 15.0]
+        self.timestamps_second_event = [1.0, 10.0, 35.0]
 
         self.event_indices = np.concatenate(
             [
@@ -62,9 +62,9 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         )
 
         self.data = np.concatenate([self.data_for_first_event, self.data_for_second_event], axis=1)
-        self.event_timestamps = np.concatenate([self.event_timestamps_first_event, self.event_timestamps_second_event])
+        self.timestamps = np.concatenate([self.timestamps_first_event, self.timestamps_second_event])
 
-        self.sorted_indices = np.argsort(self.event_timestamps)
+        self.sorted_indices = np.argsort(self.timestamps)
 
     def test_constructor(self):
         """Test that the constructor for BinnedAlignedSpikes sets values as expected."""
@@ -73,7 +73,7 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
             bin_width_in_milliseconds=self.bin_width_in_milliseconds,
             milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
             data=self.data,
-            event_timestamps=self.event_timestamps,
+            timestamps=self.timestamps,
             event_indices=self.event_indices,
         )
 
@@ -81,7 +81,7 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         np.testing.assert_array_equal(
             aggregated_binnned_align_spikes.event_indices, self.event_indices[self.sorted_indices]
         )
-        np.testing.assert_array_equal(aggregated_binnned_align_spikes.event_timestamps, self.event_timestamps[self.sorted_indices])
+        np.testing.assert_array_equal(aggregated_binnned_align_spikes.timestamps, self.timestamps[self.sorted_indices])
         self.assertEqual(aggregated_binnned_align_spikes.bin_width_in_milliseconds, self.bin_width_in_milliseconds)
         self.assertEqual(
             aggregated_binnned_align_spikes.milliseconds_from_event_to_first_bin,
@@ -98,7 +98,7 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
             bin_width_in_milliseconds=self.bin_width_in_milliseconds,
             milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
             data=self.data,
-            event_timestamps=self.event_timestamps,
+            timestamps=self.timestamps,
             event_indices=self.event_indices,
             
         )
@@ -110,8 +110,8 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         np.testing.assert_allclose(data_for_stimuli_2, self.data_for_second_event)
 
         timestamps_stimuli_1 = aggregated_binnned_align_spikes.get_timestamps_for_stimuli(event_index=0)
-        np.testing.assert_allclose(timestamps_stimuli_1, self.event_timestamps_first_event)
+        np.testing.assert_allclose(timestamps_stimuli_1, self.timestamps_first_event)
         
         timestamps_stimuli_2 = aggregated_binnned_align_spikes.get_timestamps_for_stimuli(event_index=1)
-        np.testing.assert_allclose(timestamps_stimuli_2, self.event_timestamps_second_event)
+        np.testing.assert_allclose(timestamps_stimuli_2, self.timestamps_second_event)
         

--- a/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
+++ b/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
@@ -57,7 +57,7 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         )
 
         self.timestamps_first_event = [5.0, 15.0]
-        self.timestamps_second_event = [1.0, 10.0, 35.0]
+        self.timestamps_second_event = [0.0, 10.0, 20.0]
 
         self.event_indices = np.concatenate(
             [

--- a/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
+++ b/src/pynwb/tests/test_aggregated_binned_aligned_spikes.py
@@ -1,8 +1,6 @@
 import numpy as np
 
-from pynwb import NWBHDF5IO
-from pynwb.testing.mock.file import mock_NWBFile
-from pynwb.testing import TestCase, remove_test_file
+from pynwb.testing import TestCase
 from ndx_binned_spikes import AggregatedBinnedAlignedSpikes
 
 
@@ -17,7 +15,7 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         self.number_of_events = 5
 
         self.bin_width_in_milliseconds = 20.0
-        self.milliseconds_from_event_to_first_bin = -100.0        
+        self.milliseconds_from_event_to_first_bin = -100.0
 
         # Two units in total and 4 bins, and event with two timestamps
         self.data_for_first_event_instance = np.array(
@@ -62,7 +60,6 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
 
         self.data = np.concatenate([self.data_for_first_event_instance, self.data_for_second_event_instance], axis=1)
 
-
     def test_constructor(self):
         """Test that the constructor for BinnedAlignedSpikes sets values as expected."""
 
@@ -77,24 +74,23 @@ class TestAggregatedBinnedAlignedSpikesConstructor(TestCase):
         np.testing.assert_array_equal(aggregated_binnned_align_spikes.event_indices, self.event_indices)
         self.assertEqual(aggregated_binnned_align_spikes.bin_width_in_milliseconds, self.bin_width_in_milliseconds)
         self.assertEqual(
-            aggregated_binnned_align_spikes.milliseconds_from_event_to_first_bin, self.milliseconds_from_event_to_first_bin
+            aggregated_binnned_align_spikes.milliseconds_from_event_to_first_bin,
+            self.milliseconds_from_event_to_first_bin,
         )
 
         self.assertEqual(aggregated_binnned_align_spikes.data.shape[0], self.number_of_units)
         self.assertEqual(aggregated_binnned_align_spikes.data.shape[1], self.number_of_events)
         self.assertEqual(aggregated_binnned_align_spikes.data.shape[2], self.number_of_bins)
 
-
     def test_get_single_event_data_method(self):
-        
+
         aggregated_binnned_align_spikes = AggregatedBinnedAlignedSpikes(
             bin_width_in_milliseconds=self.bin_width_in_milliseconds,
             milliseconds_from_event_to_first_bin=self.milliseconds_from_event_to_first_bin,
             data=self.data,
             event_indices=self.event_indices,
         )
-        
-        
+
         data_for_stimuli_1 = aggregated_binnned_align_spikes.get_data_for_stimuli(event_index=0)
-        
+
         np.testing.assert_allclose(data_for_stimuli_1, self.data_for_first_event_instance)

--- a/src/pynwb/tests/test_binned_aligned_spikes.py
+++ b/src/pynwb/tests/test_binned_aligned_spikes.py
@@ -1,6 +1,4 @@
 """Unit and integration tests for the example BinnedAlignedSpikes extension neurodata type.
-
-TODO: Modify these tests to test your extension neurodata type.
 """
 
 import numpy as np

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -116,8 +116,7 @@ def main():
         dims=["number_of_events"],
     )
 
-    # TODO: This prbably can inherit from the simple class and then add the stimuli index.
-    # First, we need to figure out and discuss how to handle the timestamps of the events.
+    # TODO: This probably can inherit from the simple class and then add the stimuli index.
     aggregated_binned_aligned_spikes = NWBGroupSpec(
         neurodata_type_def="AggregatedBinnedAlignedSpikes",
         neurodata_type_inc="NWBDataInterface",
@@ -139,7 +138,7 @@ def main():
                 name="description",
                 doc="A description of what the data represents",
                 dtype="text",
-                value="Spikes data binned and aligned to event timestamps.",
+                value="Spikes data binned and aligned to the timestamps of multiple events.",
             ),
             NWBAttributeSpec(
                 name="bin_width_in_milliseconds",

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -99,7 +99,15 @@ def main():
         shape=[None, None, None],
         dims=["num_units", "number_of_events", "number_of_bins"],
     )
-    
+
+    timestamps = NWBDatasetSpec(
+        name="timestamps",
+        doc="The timestamps at which the events occurred.",
+        dtype="float64",
+        shape=[None],
+        dims=["number_of_events"],
+    )    
+
     event_indices = NWBDatasetSpec(
         name="event_indices",
         doc="The index of the event that each row of the data corresponds to.",
@@ -115,9 +123,11 @@ def main():
         neurodata_type_inc="NWBDataInterface",
         default_name="AggregatedBinnedAlignedSpikes",
         doc=(
-            "A data interface for aggregated binned spike data aligned to multiple events "
-            "(e.g. a stimuli or the beginning of a trial)."
-        ),        datasets=[aggregated_binned_aligned_spikes_data, event_indices, event_timestamps, units_region],
+            "A data interface for aggregated binned spike data aligned to multiple events. "
+            "The data for all the events is concatenated along the second dimension and a second array, "
+            "event_indices, is used to keep track of which event each row of the data corresponds to."
+        ),        
+        datasets=[aggregated_binned_aligned_spikes_data, event_indices, timestamps, units_region],
         attributes=[
             NWBAttributeSpec(
                 name="name",

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -117,7 +117,7 @@ def main():
         doc=(
             "A data interface for aggregated binned spike data aligned to multiple events "
             "(e.g. a stimuli or the beginning of a trial)."
-        ),        datasets=[aggregated_binned_aligned_spikes_data, event_indices, units_region],
+        ),        datasets=[aggregated_binned_aligned_spikes_data, event_indices, event_timestamps, units_region],
         attributes=[
             NWBAttributeSpec(
                 name="name",

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -114,8 +114,10 @@ def main():
         neurodata_type_def="AggregatedBinnedAlignedSpikes",
         neurodata_type_inc="NWBDataInterface",
         default_name="AggregatedBinnedAlignedSpikes",
-        doc="A data interface for aggregated binned spike data aligned to an multiple events (e.g. a stimuli or the beginning of a trial).",
-        datasets=[aggregated_binned_aligned_spikes_data, event_indices, units_region],
+        doc=(
+            "A data interface for aggregated binned spike data aligned to multiple events "
+            "(e.g. a stimuli or the beginning of a trial)."
+        ),        datasets=[aggregated_binned_aligned_spikes_data, event_indices, units_region],
         attributes=[
             NWBAttributeSpec(
                 name="name",

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -88,9 +88,68 @@ def main():
             )
         ],
     )
+    
+    aggregated_binned_aligned_spikes_data = NWBDatasetSpec(
+        name="data",
+        doc=(
+            "The binned data. It should be an array whose first dimension is the number of units, the second dimension "
+            "is the total number of events of all stimuli, and the third dimension is the number of bins."
+            ),
+        dtype="numeric",  # TODO should this be a uint64?
+        shape=[None, None, None],
+        dims=["num_units", "number_of_events", "number_of_bins"],
+    )
+    
+    event_index = NWBDatasetSpec(
+        name="event_index",
+        doc="The index of the event that each row of the data corresponds to.",
+        dtype="int64",
+        shape=[None],
+        dims=["number_of_events"],
+    )
+
+    # TODO: This prbably can inherit from the simple class and then add the stimuli index.
+    # First, we need to figure out and discuss how to handle the timestamps of the events.
+    aggregated_binned_aligned_spikes = NWBGroupSpec(
+        neurodata_type_def="AggregatedBinnedAlignedSpikes",
+        neurodata_type_inc="NWBDataInterface",
+        default_name="AggregatedBinnedAlignedSpikes",
+        doc="A data interface for aggregated binned spike data aligned to an multiple events (e.g. a stimuli or the beginning of a trial).",
+        datasets=[aggregated_binned_aligned_spikes_data, event_index, units_region],
+        attributes=[
+            NWBAttributeSpec(
+                name="name",
+                doc="The name of this container",
+                dtype="text",
+                value="BinnedAlignedSpikes",
+            ),
+            NWBAttributeSpec(
+                name="description",
+                doc="A description of what the data represents",
+                dtype="text",
+                value="Spikes data binned and aligned to event timestamps.",
+            ),
+            NWBAttributeSpec(
+                name="bin_width_in_milliseconds",
+                doc="The length in milliseconds of the bins",
+                dtype="float64",
+            ),
+            NWBAttributeSpec(
+                name="milliseconds_from_event_to_first_bin",
+                doc=(
+                "The time in milliseconds from the event to the beginning of the first bin. A negative value indicates"
+                "that the first bin is before the event whereas a positive value indicates that the first bin is "
+                "after the event." 
+                ),
+                dtype="float64",
+                default_value=0.0,
+            )
+        ],
+    )
+    
 
     # TODO: add all of your new data types to this list
-    new_data_types = [binned_aligned_spikes]
+    new_data_types = [binned_aligned_spikes, aggregated_binned_aligned_spikes]
 
     # export the spec to yaml files in the spec folder
     output_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "spec"))

--- a/src/spec/create_extension_spec.py
+++ b/src/spec/create_extension_spec.py
@@ -100,8 +100,8 @@ def main():
         dims=["num_units", "number_of_events", "number_of_bins"],
     )
     
-    event_index = NWBDatasetSpec(
-        name="event_index",
+    event_indices = NWBDatasetSpec(
+        name="event_indices",
         doc="The index of the event that each row of the data corresponds to.",
         dtype="int64",
         shape=[None],
@@ -115,7 +115,7 @@ def main():
         neurodata_type_inc="NWBDataInterface",
         default_name="AggregatedBinnedAlignedSpikes",
         doc="A data interface for aggregated binned spike data aligned to an multiple events (e.g. a stimuli or the beginning of a trial).",
-        datasets=[aggregated_binned_aligned_spikes_data, event_index, units_region],
+        datasets=[aggregated_binned_aligned_spikes_data, event_indices, units_region],
         attributes=[
             NWBAttributeSpec(
                 name="name",


### PR DESCRIPTION
First draft/ proof of concept of an structure to get aggregated data for many events (i.e. different stimuli or events). This is an idea proposed by @bendichter and I am calling it here `AggregatedBinnedAlignedSpikes` 

I added some tests for the basic constructor and a method for getting data corresponding to a specific event `aggregated_binnned_align_spikes.get_data_for_stimuli(event_index=0)`

One point that I am still not sure about is how to manage timestamps. `BinnedAlignedSpikes` has a timestamps that stores the times at which the single event for which the data is obtained ocurred. 

We could use the same index approach that we use for the data here that we use for the timestamps but then either we would have the tiemestamps to be non-monotric or we would need to re-order the data once the user passess it to us.  Thinking on how to handle this, so far the structure does not have timestamps.

TO-DO

- [x] Add examples to the readme
- [x] Discuss timestamps
- [x] Add round-trip tests.